### PR TITLE
fix(nvim): surface runtime bindings dropped for lack of a source location

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ confhelp -b ~/other-dotfiles
 # Show keys defined more than once
 confhelp --conflicts
 
-# Report lines that look like bindings but failed to parse
+# Report lines that look like bindings but failed to parse, plus any runtime
+# bindings a query engine had to drop for lack of a source location
 confhelp --check
 ```
 
@@ -101,7 +102,36 @@ script = '~/.config/zledit/scripts/edit.sh'
 
 Some tools (like nvim) store bindings in ways that can't be reliably parsed with regex - runtime keymaps, plugin-generated bindings, multi-line table formats. Query engines run the tool itself to extract bindings.
 
-Currently available: `nvim` (runs nvim headlessly to query keymaps)
+Currently available: `nvim` (runs nvim headlessly to query keymaps) and `tmuxinator` (reads session files).
+
+**The nvim engine needs a literal `desc` at the call site.** nvim reports no source
+location for a Lua keymap: `lnum` is 0 and `sid` collapses to `init.lua` for anything
+loaded through `require`. So the engine recovers a location by grepping your config
+for the description as written, and a binding it cannot place is left out, since there
+would be nothing for `--edit` to jump to. That filter is what keeps several hundred
+plugin bindings out of the listing, but it also hides your own binding if its `desc`
+reached nvim through a variable:
+
+```lua
+-- invisible to confhelp: the literal never appears in a file
+local set = function(lhs, rhs, desc)
+  vim.keymap.set("n", lhs, rhs, { desc = desc })
+end
+set("<leader>ff", cmd, "Find files")
+
+-- visible: the call site spells the description out
+set("<leader>ff", cmd, { desc = "Find files" })
+```
+
+`confhelp --check` reports how many runtime bindings were dropped this way. Plugin
+bindings are expected in that list; yours are not. To see only your own:
+
+```bash
+confhelp --check 2>/dev/null | grep '^\[nvim\] <leader>'
+```
+
+Descriptions should be unique. The index is keyed by description text, so two bindings
+sharing one resolve to the same location (the first in sorted file order).
 
 **Architecture note:** Query engines are currently hardcoded. Future versions may support registering custom extractors - any code that returns `(type, key, desc, file, line)` tuples could become a binding source. This would allow community-contributed engines for tools like vim, emacs, i3, sway, etc.
 
@@ -156,6 +186,11 @@ type = "abbrev"
 # nvim query engine options
 [engine.nvim]
 truncate = 60
+path = ".config/nvim"      # where to grep for desc literals, relative to base_dir
+
+# tmuxinator query engine options
+[engine.tmuxinator]
+path = "~/.config/tmuxinator"
 
 # nvim via regex (alternative to query engine - parses source files directly)
 # Only catches single-line vim.keymap.set calls with inline desc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "confhelp"
-version = "0.7.0"
+version = "0.8.0"
 description = "Config-driven parser for keybindings with fzf interface"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
@@ -40,7 +41,7 @@ pythonpath = ["src"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py311"
+target-version = "py39"
 
 [tool.mutmut]
 paths_to_mutate = "src/bindings_help/"

--- a/src/bindings_help/cli.py
+++ b/src/bindings_help/cli.py
@@ -9,12 +9,13 @@ import subprocess
 import sys
 from pathlib import Path
 
-# Handle broken pipe (e.g., confhelp | head) gracefully
+# Handle broken pipe (e.g., confhelp | head) gracefully. This has to be installed
+# before iterfzf spawns anything, so the two imports below stay under it (E402).
 signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
-from iterfzf import iterfzf
+from iterfzf import iterfzf  # noqa: E402
 
-from .parser import find_conflicts, parse_all
+from .parser import find_conflicts, parse_all  # noqa: E402
 
 def get_default_config_paths() -> list[Path]:
     paths = []
@@ -158,11 +159,28 @@ def main():
         if not all_missed:
             print("All lines parsed successfully.", file=sys.stderr)
             sys.exit(0)
-        print(f"Found {len(all_missed)} unparsed line(s):\n", file=sys.stderr)
-        for m in all_missed:
-            path = m._base_dir / m.file
-            print(f"[{m.parser_name}] {path}:{m.line}")
-            print(f"  {m.content}\n")
+        unparsed = [m for m in all_missed if m.reason == "regex"]
+        dropped = [m for m in all_missed if m.reason == "no-source"]
+
+        if unparsed:
+            print(f"Found {len(unparsed)} unparsed line(s):\n", file=sys.stderr)
+            for m in unparsed:
+                path = m._base_dir / m.file
+                print(f"[{m.parser_name}] {path}:{m.line}")
+                print(f"  {m.content}\n")
+
+        if dropped:
+            print(
+                f"Dropped {len(dropped)} runtime binding(s) with no source location.\n"
+                "A query engine saw these but could not find their description as a\n"
+                "literal in your config, so they cannot be jumped to and are hidden.\n"
+                "Plugin bindings are expected here; your own are not.\n",
+                file=sys.stderr,
+            )
+            for m in dropped:
+                print(f"[{m.parser_name}] {m.content}")
+            print()
+
         sys.exit(1)
 
     # Conflicts mode: show keys defined more than once

--- a/src/bindings_help/parser.py
+++ b/src/bindings_help/parser.py
@@ -32,11 +32,17 @@ class Binding:
 
 @dataclass
 class MissedLine:
-    """A line that matched match_line but failed regex."""
+    """Something that looked like a binding but did not make it into the output.
+
+    reason "regex" is a source line that matched match_line but failed the regex.
+    reason "no-source" is a runtime binding a query engine found but could not
+    trace back to a config file, so it was dropped from the listing.
+    """
     file: str
     line: int
     content: str
     parser_name: str
+    reason: str = "regex"
 
 
 def load_config(config_path: Path) -> dict:
@@ -202,7 +208,7 @@ def _parse_file_structured(
 
 def query_tmuxinator_sessions(cfg: dict, base_dir: Optional[Path] = None) -> list[Binding]:
     """Query tmuxinator session files."""
-    tmuxinator_dir = Path.home() / ".config/tmuxinator"
+    tmuxinator_dir = Path(cfg.get("path", "~/.config/tmuxinator")).expanduser()
     if not tmuxinator_dir.exists():
         return []
 
@@ -243,7 +249,69 @@ def query_tmuxinator_sessions(cfg: dict, base_dir: Optional[Path] = None) -> lis
     return bindings
 
 
-def query_nvim_keymaps(cfg: dict, base_dir: Optional[Path] = None) -> list[Binding]:
+def build_desc_index(nvim_dir: Path, base_dir: Path) -> dict[str, tuple[str, int]]:
+    """Map a description literal to the file and line that spells it out.
+
+    nvim's API reports no source location for a Lua keymap (lnum is 0 and sid
+    collapses to init.lua for anything loaded through require), so the only way
+    back to a file is to grep for the desc as it was written. Files are walked in
+    sorted order and the first occurrence wins, so a description used twice always
+    resolves to the same place instead of varying with filesystem order.
+    """
+    index: dict[str, tuple[str, int]] = {}
+    if not nvim_dir.exists():
+        return index
+
+    for lua_path in sorted(nvim_dir.rglob("*.lua")):
+        try:
+            lines = lua_path.read_text().splitlines()
+        except (OSError, UnicodeDecodeError):
+            continue
+        for i, line in enumerate(lines, 1):
+            # Match quote type separately to handle apostrophes in strings
+            match = re.search(r'desc\s*=\s*"([^"]+)"', line)
+            if not match:
+                match = re.search(r"desc\s*=\s*'([^']+)'", line)
+            if match and match.group(1) not in index:
+                index[match.group(1)] = (str(lua_path.relative_to(base_dir)), i)
+
+    return index
+
+
+def bindings_from_keymap_output(
+    output: str,
+    desc_locations: dict[str, tuple[str, int]],
+    truncate: int = 60,
+    missed: Optional[list] = None,
+) -> list[Binding]:
+    """Turn `lhs|desc` lines from the headless query into bindings.
+
+    A binding whose description is not in the index cannot be jumped to, so it is
+    left out of the listing. That is what keeps several hundred plugin bindings
+    out of the output, but it also swallows a user binding whose desc reached nvim
+    through a variable. Every drop is recorded in `missed` so --check can show it.
+    """
+    bindings = []
+    for line in output.strip().split("\n"):
+        if not line or "|" not in line:
+            continue
+        key, desc = line.split("|", 1)
+        if desc not in desc_locations:
+            if missed is not None:
+                missed.append(
+                    MissedLine("", 0, f"{key}  {desc}", "nvim", reason="no-source")
+                )
+            continue
+        src, line_num = desc_locations[desc]
+        if truncate and len(desc) > truncate:
+            desc = desc[:truncate]
+        bindings.append(Binding("nvim", key, desc, src, line_num))
+    return bindings
+
+
+def query_nvim_keymaps(
+    cfg: dict, base_dir: Optional[Path] = None, missed: Optional[list] = None
+) -> list[Binding]:
     """Query nvim for keymaps via headless execution."""
     if not shutil.which("nvim"):
         return []
@@ -277,44 +345,17 @@ end
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return []
 
-    # Build desc->location index by grepping nvim config files
     desc_locations: dict[str, tuple[str, int]] = {}
     if base_dir:
-        nvim_dir = base_dir / ".config/nvim"
-        if nvim_dir.exists():
-            for lua_path in nvim_dir.rglob("*.lua"):
-                try:
-                    for i, line in enumerate(lua_path.read_text().splitlines(), 1):
-                        # Look for desc = "..." or desc = '...' patterns
-                        # Match quote type separately to handle apostrophes in strings
-                        match = re.search(r'desc\s*=\s*"([^"]+)"', line)
-                        if not match:
-                            match = re.search(r"desc\s*=\s*'([^']+)'", line)
-                        if match:
-                            desc_locations[match.group(1)] = (
-                                str(lua_path.relative_to(base_dir)),
-                                i,
-                            )
-                except (OSError, UnicodeDecodeError):
-                    continue
+        nvim_dir = base_dir / cfg.get("path", ".config/nvim")
+        desc_locations = build_desc_index(nvim_dir, base_dir)
 
-    bindings = []
-    truncate = cfg.get("truncate", 60)
-    output = result.stderr or result.stdout
-    for line in output.strip().split("\n"):
-        if not line or "|" not in line:
-            continue
-        parts = line.split("|", 1)
-        if len(parts) >= 2:
-            key, desc = parts[0], parts[1]
-            # Find source location from desc - skip plugin bindings without source
-            if desc not in desc_locations:
-                continue
-            src, line_num = desc_locations[desc]
-            if truncate and len(desc) > truncate:
-                desc = desc[:truncate]
-            bindings.append(Binding("nvim", key, desc, src, line_num))
-    return bindings
+    return bindings_from_keymap_output(
+        result.stderr or result.stdout,
+        desc_locations,
+        cfg.get("truncate", 60),
+        missed,
+    )
 
 
 def _get_line_number(content: str, pos: int) -> int:
@@ -459,7 +500,11 @@ def parse_all(
     for engine in query_engines:
         if engine == "nvim":
             nvim_cfg = engine_configs.get("nvim", {})
-            all_results.extend(query_nvim_keymaps(nvim_cfg, base_dir))
+            all_results.extend(
+                query_nvim_keymaps(
+                    nvim_cfg, base_dir, all_missed if collect_missed else None
+                )
+            )
         elif engine == "tmuxinator":
             tmux_cfg = engine_configs.get("tmuxinator", {})
             all_results.extend(query_tmuxinator_sessions(tmux_cfg, base_dir))

--- a/src/bindings_help/parser.py
+++ b/src/bindings_help/parser.py
@@ -200,6 +200,49 @@ def _parse_file_structured(
     return results
 
 
+def query_tmuxinator_sessions(cfg: dict, base_dir: Optional[Path] = None) -> list[Binding]:
+    """Query tmuxinator session files."""
+    tmuxinator_dir = Path.home() / ".config/tmuxinator"
+    if not tmuxinator_dir.exists():
+        return []
+
+    bindings = []
+    for yml_file in sorted(tmuxinator_dir.glob("*.yml")):
+        try:
+            content = yml_file.read_text()
+            data = yaml.safe_load(content)
+            if not isinstance(data, dict):
+                continue
+
+            # Get session name (from 'name' field or filename)
+            name = data.get("name", yml_file.stem)
+            # Handle ERB templates like "<%= @args[0] %>"
+            if "<%=" in str(name):
+                name = yml_file.stem
+
+            # Get root directory as description
+            root = data.get("root", "~")
+
+            # Find line number of 'name:' field
+            line_num = 1
+            for i, line in enumerate(content.splitlines(), 1):
+                if line.strip().startswith("name:"):
+                    line_num = i
+                    break
+
+            bindings.append(Binding(
+                "mux",
+                name,
+                root,
+                yml_file.name,
+                line_num
+            ))
+        except (OSError, yaml.YAMLError):
+            continue
+
+    return bindings
+
+
 def query_nvim_keymaps(cfg: dict, base_dir: Optional[Path] = None) -> list[Binding]:
     """Query nvim for keymaps via headless execution."""
     if not shutil.which("nvim"):
@@ -417,6 +460,9 @@ def parse_all(
         if engine == "nvim":
             nvim_cfg = engine_configs.get("nvim", {})
             all_results.extend(query_nvim_keymaps(nvim_cfg, base_dir))
+        elif engine == "tmuxinator":
+            tmux_cfg = engine_configs.get("tmuxinator", {})
+            all_results.extend(query_tmuxinator_sessions(tmux_cfg, base_dir))
 
     for name, cfg in config.items():
         # Skip non-parser entries

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -5,7 +5,10 @@ from pathlib import Path
 
 import pytest
 
-from bindings_help.parser import parse_file, parse_all, load_config, Binding, find_conflicts, MissedLine
+from bindings_help.parser import (
+    parse_file, parse_all, load_config, Binding, find_conflicts, MissedLine,
+    build_desc_index, bindings_from_keymap_output, query_tmuxinator_sessions,
+)
 
 
 @pytest.fixture
@@ -901,3 +904,131 @@ class TestFindLineForValue:
 
         content = 'key = "ctrl+shift+p"\nother'
         assert _find_line_for_value(content, "ctrl+shift+p") == 1
+
+
+class TestNvimDescIndex:
+    """The desc->location index, which had no coverage before.
+
+    nvim reports no source location for a Lua keymap, so confhelp recovers one by
+    grepping for the description literal. Everything the index cannot place is
+    dropped from the listing, which makes these two functions the point where a
+    real binding can silently disappear.
+    """
+
+    def test_index_finds_double_and_single_quoted_desc(self, temp_dir):
+        nvim = temp_dir / ".config/nvim/lua"
+        nvim.mkdir(parents=True)
+        (nvim / "maps.lua").write_text(
+            'vim.keymap.set("n", "<leader>a", cmd, { desc = "double quoted" })\n'
+            "vim.keymap.set('n', '<leader>b', cmd, { desc = 'single quoted' })\n"
+        )
+
+        index = build_desc_index(temp_dir / ".config/nvim", temp_dir)
+
+        assert index["double quoted"] == (".config/nvim/lua/maps.lua", 1)
+        assert index["single quoted"] == (".config/nvim/lua/maps.lua", 2)
+
+    def test_duplicate_desc_resolves_to_the_first_file_in_sorted_order(self, temp_dir):
+        """Two files claiming one description must not swap places between runs.
+
+        rglob order is filesystem-dependent, so last-wins made the reported location
+        for a shared description unstable.
+        """
+        nvim = temp_dir / ".config/nvim"
+        nvim.mkdir(parents=True)
+        (nvim / "a_first.lua").write_text('{ desc = "shared" }\n')
+        (nvim / "z_last.lua").write_text('{ desc = "shared" }\n')
+
+        for _ in range(3):
+            assert build_desc_index(nvim, temp_dir)["shared"] == (".config/nvim/a_first.lua", 1)
+
+    def test_missing_nvim_dir_yields_empty_index(self, temp_dir):
+        assert build_desc_index(temp_dir / "nope", temp_dir) == {}
+
+    def test_unreadable_file_is_skipped_not_fatal(self, temp_dir):
+        nvim = temp_dir / ".config/nvim"
+        nvim.mkdir(parents=True)
+        (nvim / "binary.lua").write_bytes(b"\xff\xfe\x00 desc = \"x\"")
+        (nvim / "good.lua").write_text('{ desc = "reachable" }\n')
+
+        assert "reachable" in build_desc_index(nvim, temp_dir)
+
+
+class TestNvimKeymapOutput:
+    def test_binding_with_a_known_desc_is_kept(self):
+        index = {"Find files": ("lua/telescope.lua", 12)}
+
+        result = bindings_from_keymap_output("<leader>ff|Find files", index)
+
+        assert result == [Binding("nvim", "<leader>ff", "Find files", "lua/telescope.lua", 12)]
+
+    def test_binding_with_no_source_is_dropped(self):
+        """This is the filter that keeps hundreds of plugin bindings out."""
+        assert bindings_from_keymap_output("<leader>x|from a plugin", {}) == []
+
+    def test_dropped_binding_is_recorded_when_a_collector_is_passed(self):
+        """The drop used to be silent, so a real binding could vanish unnoticed."""
+        missed = []
+
+        bindings_from_keymap_output("<leader>x|desc via a variable", {}, missed=missed)
+
+        assert len(missed) == 1
+        assert missed[0].reason == "no-source"
+        assert missed[0].parser_name == "nvim"
+        assert "<leader>x" in missed[0].content
+
+    def test_no_collector_means_no_recording(self):
+        assert bindings_from_keymap_output("<leader>x|orphan", {}) == []
+
+    def test_desc_is_truncated_but_matched_at_full_length(self):
+        """Truncation must happen after the lookup, or long descs stop resolving."""
+        long_desc = "d" * 80
+        index = {long_desc: ("maps.lua", 1)}
+
+        result = bindings_from_keymap_output(f"<leader>l|{long_desc}", index, truncate=60)
+
+        assert len(result) == 1
+        assert result[0].desc == "d" * 60
+
+    def test_blank_and_malformed_lines_are_ignored(self):
+        index = {"real": ("maps.lua", 1)}
+        missed = []
+
+        result = bindings_from_keymap_output(
+            "\nno-pipe-here\n<leader>r|real\n", index, missed=missed
+        )
+
+        assert [b.key for b in result] == ["<leader>r"]
+        assert missed == []
+
+
+class TestTmuxinatorEngine:
+    """The engine used to read ~/.config/tmuxinator unconditionally, which made it
+    untestable and unusable against a second config root."""
+
+    def test_reads_sessions_from_a_configured_path(self, temp_dir):
+        sessions = temp_dir / "sessions"
+        sessions.mkdir()
+        (sessions / "work.yml").write_text("name: work\nroot: ~/dev/work\n")
+
+        result = query_tmuxinator_sessions({"path": str(sessions)})
+
+        assert result == [Binding("mux", "work", "~/dev/work", "work.yml", 1)]
+
+    def test_erb_templated_name_falls_back_to_the_filename(self, temp_dir):
+        sessions = temp_dir / "sessions"
+        sessions.mkdir()
+        (sessions / "generic.yml").write_text('name: "<%= @args[0] %>"\nroot: ~/\n')
+
+        assert query_tmuxinator_sessions({"path": str(sessions)})[0].key == "generic"
+
+    def test_missing_directory_yields_nothing(self, temp_dir):
+        assert query_tmuxinator_sessions({"path": str(temp_dir / "nope")}) == []
+
+    def test_malformed_yaml_is_skipped_not_fatal(self, temp_dir):
+        sessions = temp_dir / "sessions"
+        sessions.mkdir()
+        (sessions / "broken.yml").write_text("name: [unclosed\n")
+        (sessions / "good.yml").write_text("name: good\nroot: ~/\n")
+
+        assert [b.key for b in query_tmuxinator_sessions({"path": str(sessions)})] == ["good"]

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "confhelp"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "iterfzf" },


### PR DESCRIPTION
A telescope config defined 21 pickers through a local helper that swallowed the opts table. All 21 were live in nvim and all 21 were absent from `confhelp` output, with nothing anywhere saying so. The engine had found them and discarded them one step later.

## Why they vanished

nvim reports no source location for a Lua keymap. `lnum` is 0 for every one of them, and `sid` collapses to `init.lua` for anything loaded through `require`, so the only route back to a file is grepping for the `desc` as written. Anything the grep cannot place gets dropped, which is what keeps roughly 500 plugin bindings out of the listing. The rule is right. Its silence was not: a binding of your own whose `desc` reached nvim through a variable looks exactly like a plugin binding to that filter.

## Changes

Drops are counted and reported under `--check`, so `grep '^\[nvim\] <leader>'` answers "did I lose any of mine". On the dotfiles this was found in, 522 drops, none of them leader keys.

Files are walked in sorted order with first match winning. `rglob` order is filesystem-dependent, so a description used twice could previously resolve to either file between runs.

`build_desc_index` and `bindings_from_keymap_output` are split out of `query_nvim_keymaps`. That is what makes the path testable without a working nvim, which is why it had no coverage before: the only existing test asserted the behaviour when nvim is not installed.

Both engines take a `path` option instead of hardcoding `.config/nvim` and `~/.config/tmuxinator`.

README documents the desc-literal requirement with the before/after Lua, since that is the trap.

## Housekeeping (second commit)

`uv.lock` still said 0.7.0 after the bump in 36bb224 touched pyproject alone. Ruff checked against py311 while the package claims 3.9, so a 3.10-only construct would have passed review and failed for a user. Classifiers and the CI matrix now include 3.13. The two imports under the SIGPIPE handler carry a `noqa` and a note rather than standing as permanent lint errors.

## Verification

- 85 tests pass, up from 71.
- `ruff check src/` clean.
- Normal output byte-identical: 700 lines before and after, same 29 mux and 272 nvim entries. The only behaviour change is `--check`.

Version goes to 0.8.0. Publishing fires on push to main, so merging this releases it.