### PR TITLE
feat(parser): reach nested fields and stop pipes corrupting the row

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "confhelp"
-version = "0.8.0"
+version = "0.9.0"
 description = "Config-driven parser for keybindings with fzf interface"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/bindings_help/parser.py
+++ b/src/bindings_help/parser.py
@@ -27,7 +27,12 @@ class Binding:
     line: int
 
     def to_line(self) -> str:
-        return f"[{self.type}]|{self.key}|{self.desc.replace('|', '¦')}|{self.file}:{self.line}"
+        # Both key and desc are escaped: alacritty spells a modifier combination
+        # Shift|Control, which would otherwise split into two extra columns and
+        # shift every field right for the awk consumers.
+        key = self.key.replace("|", "¦")
+        desc = self.desc.replace("|", "¦")
+        return f"[{self.type}]|{key}|{desc}|{self.file}:{self.line}"
 
 
 @dataclass
@@ -171,15 +176,17 @@ def _parse_file_structured(
     # Optional: combine multiple fields for key or desc
     # If key/desc contains "+" it means combine fields: "mods+key"
     def extract_field(entry: dict, field_spec: str) -> str:
+        # Fields may be dotted so a nested value can be named directly. Alacritty
+        # spells a hint as binding = { key, mods } with command = { program, args },
+        # and a flat entry.get() reaches neither.
+        def one(spec: str) -> str:
+            val = _navigate_path(entry, spec.strip())
+            return "" if val is None else str(val)
+
         if "+" in field_spec:
-            parts = field_spec.split("+")
-            values = []
-            for p in parts:
-                val = entry.get(p.strip(), "")
-                if val:
-                    values.append(str(val))
+            values = [v for v in (one(p) for p in field_spec.split("+")) if v]
             return "+".join(values) if values else ""
-        return str(entry.get(field_spec, ""))
+        return one(field_spec)
 
     results = []
     last_line = 1

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1032,3 +1032,60 @@ class TestTmuxinatorEngine:
         (sessions / "good.yml").write_text("name: good\nroot: ~/\n")
 
         assert [b.key for b in query_tmuxinator_sessions({"path": str(sessions)})] == ["good"]
+
+
+class TestStructuredDottedFields:
+    """Nested fields, e.g. alacritty's binding = { key, mods } under hints.enabled."""
+
+    CFG = {"parser": "toml", "binding_path": "hints.enabled",
+           "key": "binding.mods+binding.key", "desc": "command.program", "type": "hint"}
+
+    def test_dotted_key_and_desc_reach_nested_values(self, temp_dir):
+        f = temp_dir / "alacritty.toml"
+        f.write_text(
+            "[[hints.enabled]]\n"
+            'command = { program = "/bin/sh", args = ["-c", "true"] }\n'
+            'binding = { key = "1", mods = "Control" }\n'
+        )
+
+        result, _ = parse_file(f, self.CFG, "alacritty.toml")
+
+        assert result[0].key == "Control+1"
+        assert result[0].desc == "/bin/sh"
+
+    def test_flat_fields_still_work(self, temp_dir):
+        """The dotted lookup must not regress the ordinary single-level case."""
+        f = temp_dir / "alacritty.toml"
+        f.write_text('[[keyboard.bindings]]\nkey = "Y"\nmods = "Control"\naction = "Copy"\n')
+
+        cfg = {"parser": "toml", "binding_path": "keyboard.bindings",
+               "key": "mods+key", "desc": "action", "type": "key"}
+        result, _ = parse_file(f, cfg, "alacritty.toml")
+
+        assert result[0].key == "Control+Y"
+        assert result[0].desc == "Copy"
+
+    def test_absent_nested_field_is_empty_not_an_error(self, temp_dir):
+        f = temp_dir / "alacritty.toml"
+        f.write_text('[[hints.enabled]]\nbinding = { key = "1" }\n')
+
+        result, _ = parse_file(f, self.CFG, "alacritty.toml")
+
+        assert result[0].key == "1"
+        assert result[0].desc == ""
+
+
+class TestPipeEscaping:
+    """The output row is pipe-delimited and consumers split on it with awk."""
+
+    def test_a_pipe_in_the_key_is_escaped(self):
+        """alacritty spells a modifier combination Shift|Control."""
+        line = Binding("alacritty", "Shift|Control+Space", "ToggleViMode", "a.toml", 3).to_line()
+
+        assert line.count("|") == 3, line
+        assert "Shift¦Control+Space" in line
+
+    def test_a_pipe_in_the_desc_is_escaped(self):
+        line = Binding("tmux", "M-x", "sh -c 'a | b'", "t.conf", 9).to_line()
+
+        assert line.count("|") == 3, line

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "confhelp"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "iterfzf" },


### PR DESCRIPTION
Both defects surfaced while wiring alacritty into a real config, and neither was visible from the test suite alone.

## Nested fields were unreachable

Alacritty spells a hint as `binding = { key = "1", mods = "Control" }` with `command = { program = "/bin/sh", args = [...] }`, so both the key and its description sit one level down. The structured parser only ever did a flat `entry.get()`, so no alacritty hint could be given a description at all.

`key` and `desc` now accept a dotted path, routed through the same `_navigate_path` that `binding_path` already used, so `key = "binding.mods+binding.key"` and `desc = "command.program"` work. The flat single-level form is untouched and has a regression test.

## A pipe in the key corrupted the row

The output row is `[type]|key|desc|file:line` and every consumer splits on it, including the awk in `__config_bindings_help.sh`. `desc` was escaped; `key` was not. Alacritty writes a modifier combination as `Shift|Control`, which produced:

```
[alacritty]|Shift|Control+Space|ToggleViMode|.config/alacritty/alacritty.toml:3
```

Five columns instead of four. The fzf view showed a mangled row, and the `file:line` it tried to jump to was read out of the wrong column. Both fields are escaped now.

## Verification

90 tests pass, up from 85. `ruff check src/` clean. New coverage for the dotted lookup (including that the flat form still works and an absent nested field yields empty rather than raising) and for pipe escaping in both fields.